### PR TITLE
[ci] Run tests against PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
 
 before_script:
   - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then composer install -n ; fi


### PR DESCRIPTION
Update config for Travis-CI to allow run tests against PHP 7.1.